### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/DHT22/ez_setup.py
+++ b/DHT22/ez_setup.py
@@ -112,8 +112,7 @@ def archive_context(filename):
 
 
 def _do_download(version, download_base, to_dir, download_delay):
-    egg = os.path.join(to_dir, 'setuptools-%s-py%d.%d.egg'
-                       % (version, sys.version_info[0], sys.version_info[1]))
+    egg = os.path.join(to_dir, 'setuptools-{0!s}-py{1:d}.{2:d}.egg'.format(version, sys.version_info[0], sys.version_info[1]))
     if not os.path.exists(egg):
         archive = download_setuptools(version, download_base,
                                       to_dir, download_delay)
@@ -278,7 +277,7 @@ def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     """
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    zip_name = "setuptools-%s.zip" % version
+    zip_name = "setuptools-{0!s}.zip".format(version)
     url = download_base + zip_name
     saveto = os.path.join(to_dir, zip_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads

--- a/daemon11.py
+++ b/daemon11.py
@@ -132,5 +132,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon12.py
+++ b/daemon12.py
@@ -140,5 +140,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon13.py
+++ b/daemon13.py
@@ -147,5 +147,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon14.py
+++ b/daemon14.py
@@ -151,5 +151,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon15.py
+++ b/daemon15.py
@@ -138,5 +138,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon22.py
+++ b/daemon22.py
@@ -170,5 +170,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon23.py
+++ b/daemon23.py
@@ -179,5 +179,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon24.py
+++ b/daemon24.py
@@ -173,5 +173,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon25.py
+++ b/daemon25.py
@@ -164,5 +164,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon97.py
+++ b/daemon97.py
@@ -34,7 +34,7 @@ class MyDaemon(Daemon):
     except mdb.Error, e:
       if DEBUG:
         print "Unexpected MySQL error"
-        print "Error %d: %s" % (e.args[0],e.args[1])
+        print "Error {0:d}: {1!s}".format(e.args[0], e.args[1])
       if consql:    # attempt to close connection to MySQLdb
         if DEBUG:print "Closing MySQL connection"
         consql.close()
@@ -103,19 +103,19 @@ def do_writesample(cnsql, cmd, sample):
   except mdb.Error, e:
     fail = True
     print "*** MySQL error"
-    print "**** Error %d: %s" % (e.args[0],e.args[1])
+    print "**** Error {0:d}: {1!s}".format(e.args[0], e.args[1])
     if cursql:    # attempt to close connection to MySQLdb
       print "***** Closing cursor"
       cursql.close()
     print(e.__doc__)
     syslog.syslog(syslog.LOG_ALERT,e.__doc__)
-    logtext = "  ** %s" % (cmd)
+    logtext = "  ** {0!s}".format((cmd))
     syslog.syslog(syslog.LOG_ALERT,logtext)
-    logtext = "  ** %s" % (sample)
+    logtext = "  ** {0!s}".format((sample))
     syslog.syslog(syslog.LOG_ALERT,logtext)
-    logtext = "  ** %s" % (e.args[0])
+    logtext = "  ** {0!s}".format((e.args[0]))
     syslog.syslog(syslog.LOG_ALERT,logtext)
-    logtext = "  ** %s" % (e.args[1])
+    logtext = "  ** {0!s}".format((e.args[1]))
     syslog.syslog(syslog.LOG_ALERT,logtext)
     syslog_trace(traceback.format_exc())
     if e.args[0] == 2006:
@@ -216,5 +216,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon98.py
+++ b/daemon98.py
@@ -136,5 +136,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/daemon99.py
+++ b/daemon99.py
@@ -167,5 +167,5 @@ if __name__ == "__main__":
       sys.exit(2)
     sys.exit(0)
   else:
-    print "usage: %s start|stop|restart|foreground" % sys.argv[0]
+    print "usage: {0!s} start|stop|restart|foreground".format(sys.argv[0])
     sys.exit(2)

--- a/libdaemon.py
+++ b/libdaemon.py
@@ -33,7 +33,7 @@ class Daemon:
         # exit first parent
         sys.exit(0)
     except OSError, e:
-      sys.stderr.write("fork no.1 failed: %d (%s)\n" % (e.errno, e.strerror))
+      sys.stderr.write("fork no.1 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
       sys.exit(1)
 
     # decouple from parent environment
@@ -48,7 +48,7 @@ class Daemon:
         # exit from second parent
         sys.exit(0)
     except OSError, e:
-      sys.stderr.write("fork no.2 failed: %d (%s)\n" % (e.errno, e.strerror))
+      sys.stderr.write("fork no.2 failed: {0:d} ({1!s})\n".format(e.errno, e.strerror))
       sys.exit(1)
 
     # redirect standard file descriptors
@@ -64,7 +64,7 @@ class Daemon:
     # write pidfile
     atexit.register(self.delpid)
     pid = str(os.getpid())
-    file(self.pidfile,'w+').write("%s\n" % pid)
+    file(self.pidfile,'w+').write("{0!s}\n".format(pid))
 
   def delpid(self):
     os.remove(self.pidfile)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Mausy5043:bonediagd?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Mausy5043:bonediagd?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)